### PR TITLE
Update Dutch and Spanish dictionaries

### DIFF
--- a/dutch/definition.yaml
+++ b/dutch/definition.yaml
@@ -13,8 +13,8 @@ dictionaries:
   url: https://www.deepl.com/translator#nl/en/[LUTE]
   active: true
 - for: terms
-  type: popup
-  url: https://www.vandale.nl/gratis-woordenboek/nederlands/betekenis/[LUTE]
+  type: embedded
+  url: https://nl-en.dict.cc/?s=[LUTE]
   active: true
 - for: terms
   type: embedded

--- a/spanish/definition.yaml
+++ b/spanish/definition.yaml
@@ -20,6 +20,10 @@ dictionaries:
   type: popup
   url: https://conjugator.reverso.net/conjugation-spanish-verb-[LUTE].html
   active: true
+- for: terms
+  type: embedded
+  url: https://es-en.dict.cc/?s=[LUTE]
+  active: true
 show_romanization: false
 right_to_left: false
 parser_type: spacedel


### PR DESCRIPTION
- Removed https://www.vandale.nl dictionary (Dutch) because it is no longer available
- Added https://dict.cc dictionaries for Dutch and Spanish