### PR TITLE
[BE] Add more embedded URLs for terms in definition.yaml

### DIFF
--- a/belarusian/definition.yaml
+++ b/belarusian/definition.yaml
@@ -7,6 +7,12 @@ dictionaries:
 - for: terms
   type: embedded
   url: https://be.wiktionary.org/wiki/[LUTE]
+- for: terms
+  type: embedded
+  url: https://verbum.by/?q=[LUTE]
+- for: terms
+  type: embedded
+  url: https://slounik.org/search?dict=&search=[LUTE]
   active: false
 - for: terms
   type: popup


### PR DESCRIPTION
Hi! I've added two main services with online dictionaries for Belarusian languages. The first one, verbum, is the most advanced one with some support from academia and the Belarusian Institute of Linguistics. The second one is a bit older, but also very useful with descent OCR-ed dictionaries in it.
We, Belarusian philologians, use those two services very often.